### PR TITLE
Python 2.7 to Python 3.x

### DIFF
--- a/brainwallet-check.py
+++ b/brainwallet-check.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     amount_response = urllib.request.urlopen("http://blockchain.info/q/addressbalance/" + str(bcaddy))
     amount = amount_response.read().decode('utf-8')
 
-    print ("-----------------------------------------------------")
+    print ("------------------------------------------------------")
     print ("brainwallet string: " + word)
     print ("private key: " + str(privatekeysha))
     print ("bitcoin address: " + str(bcaddy))

--- a/brainwallet-check.py
+++ b/brainwallet-check.py
@@ -7,47 +7,57 @@
 # - Josh Gilmour
 
 import os
-import sys, getopt
+import sys
 import ecdsa
-import urllib2
+import urllib.request  # Import the correct module
 import binascii, hashlib
 
 secp256k1curve=ecdsa.ellipticcurve.CurveFp(115792089237316195423570985008687907853269984665640564039457584007908834671663,0,7)
 secp256k1point=ecdsa.ellipticcurve.Point(secp256k1curve,0x79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798,0x483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8,0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141)
 secp256k1=ecdsa.curves.Curve('secp256k1',secp256k1curve,secp256k1point,(1,3,132,0,10))
 
-def addy(pk):
- pko=ecdsa.SigningKey.from_secret_exponent(pk,secp256k1)
- pubkey=binascii.hexlify(pko.get_verifying_key().to_string())
- pubkey2=hashlib.sha256(binascii.unhexlify('04'+pubkey)).hexdigest()
- pubkey3=hashlib.new('ripemd160',binascii.unhexlify(pubkey2)).hexdigest()
- pubkey4=hashlib.sha256(binascii.unhexlify('00'+pubkey3)).hexdigest()
- pubkey5=hashlib.sha256(binascii.unhexlify(pubkey4)).hexdigest()
- pubkey6=pubkey3+pubkey5[:8]
- pubnum=int(pubkey6,16)
- pubnumlist=[]
- while pubnum!=0: pubnumlist.append(pubnum%58); pubnum/=58
- address=''
- for l in ['123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'[x] for x in pubnumlist]:
-  address=l+address
- return '1'+address
+def addy(pk):  
+    pko=ecdsa.SigningKey.from_secret_exponent(pk,secp256k1)
+    pubkey=binascii.hexlify(pko.get_verifying_key().to_string())
+    pubkey2=hashlib.sha256(binascii.unhexlify(b'04'+pubkey)).hexdigest()  # Encode as bytes
+    pubkey3=hashlib.new('ripemd160',binascii.unhexlify(pubkey2)).hexdigest()
+    pubkey4=hashlib.sha256(binascii.unhexlify(b'00'+pubkey3.encode())).hexdigest()  # Encode '00' and pubkey3 as bytes
+    pubkey5=hashlib.sha256(binascii.unhexlify(pubkey4)).hexdigest()
+    pubkey6=pubkey3+pubkey5[:8]
+    pubnum=int(pubkey6,16)
+    pubnumlist=[]
+    while pubnum!=0: pubnumlist.append(pubnum%58); pubnum//=58
+    address=''
+    for l in ['123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'[x] for x in pubnumlist]:
+        address=l+address
+    return '1'+address
 
 if __name__ == "__main__":
-  if len(sys.argv) != 2:
-    sys.exit("ERROR: Provide brainwallet string as parameter\n./brainwallet-check.py 'Satoshi Nakamoto'")
-  privatekey = (int(hashlib.sha256(sys.argv[1]).hexdigest(),16))
-  privatekeysha = (hashlib.sha256(sys.argv[1])).hexdigest()
-  bcaddy = addy(privatekey)
-  word = str(sys.argv[1])
-  firstseen = os.popen("GET http://blockchain.info/q/addressfirstseen/" + str(bcaddy)).read()
-  amount = os.popen("GET http://blockchain.info/q/addressbalance/" + str(bcaddy)).read()
-  print "-----------------------------------------------------"
-  print "brainwallet string: " + word
-  print "private key: " + str(privatekeysha)
-  print "bitcoin address: " + str(bcaddy)
-  if str(firstseen) == "null":
-    print "[ADDRESS ISN'T IN USE ACCORDING TO BLOCKCHAIN.INFO]"
-  else:
-    print "First seen according to blockchain.info: " + firstseen
-    print "Wallet amount: " + amount
-  print "-----------------------------------------------------"
+    if len(sys.argv) != 2:
+        sys.exit("ERROR: Provide brainwallet string as parameter\n./brainwallet-check.py 'Satoshi Nakamoto'")
+    
+    input_string = sys.argv[1].encode('utf-8')  # Encode the input string as bytes
+    privatekey = int(hashlib.sha256(input_string).hexdigest(), 16)
+    privatekeysha = hashlib.sha256(input_string).hexdigest()
+    bcaddy = addy(privatekey)
+    
+    word = sys.argv[1]
+    
+    # firstseen = os.popen("GET http://blockchain.info/q/addressfirstseen/" + str(bcaddy)).read()
+    # amount = os.popen("GET http://blockchain.info/q/addressbalance/" + str(bcaddy)).read()
+    
+    firstseen_response = urllib.request.urlopen("http://blockchain.info/q/addressfirstseen/" + str(bcaddy))
+    firstseen = firstseen_response.read().decode('utf-8')
+    amount_response = urllib.request.urlopen("http://blockchain.info/q/addressbalance/" + str(bcaddy))
+    amount = amount_response.read().decode('utf-8')
+
+    print ("-----------------------------------------------------")
+    print ("brainwallet string: " + word)
+    print ("private key: " + str(privatekeysha))
+    print ("bitcoin address: " + str(bcaddy))
+    if str(firstseen) == "null":
+        print ("[ADDRESS ISN'T IN USE ACCORDING TO BLOCKCHAIN.INFO]")
+    else:
+        print ("First seen according to blockchain.info: " + firstseen)
+        print ("Wallet amount: " + amount)
+    print ("-----------------------------------------------------")


### PR DESCRIPTION
Thank you very much for sharing your code, I really liked it and that is why I have taken the liberty to adapt it to python3.

**Original**:

```
pubkey2=hashlib.sha256(binascii.unhexlify('04'+pubkey)).hexdigest()
pubkey4=hashlib.sha256(binascii.unhexlify('00'+pubkey3)).hexdigest()

```
**Final Code:**

```
pubkey2=hashlib.sha256(binascii.unhexlify(b'04'+pubkey)).hexdigest()  # Encode as bytes
pubkey4=hashlib.sha256(binascii.unhexlify(b'00'+pubkey3.encode())).hexdigest()  # Encode '00' and pubkey3 as bytes

```
In the final version of the code, specific changes have been made to ensure that concatenation operations are carried out correctly. Here's the detailed explanation of the changes:

**pubkey2 Encoding:**

Originally, pubkey is a string of hexadecimal digits. To use it with the hashlib.sha256 function, you need to convert it into bytes. In the final version, a b is added before the string '04'+pubkey, indicating that it's bytes rather than a string.

**pubkey4 Encoding:**

Similarly, you need to convert '00'+pubkey3 into bytes before passing it to the hashlib.sha256 function. However, in this case, pubkey3 is a hexadecimal string, so you need to explicitly encode it using .encode(). Hence, b'00'+pubkey3.encode() is used.

**Input String Encoding:**

Also, in the main code block section, a line has been added to encode the input string (sys.argv[1]) into bytes using .encode('utf-8'). This is necessary to ensure that the input is handled properly in the hash operations. In the original version, the input was used directly, causing issues with hash operations in Python 3.

**GET Request with urllib.request:**

The part of the code that handles GET requests using urllib.request is well implemented and doesn't require any changes. This allows the script to retrieve information from blockchain.info.

These changes are made to ensure compatibility with Python 3 and to ensure that concatenation and manipulation of strings and bytes are done correctly.